### PR TITLE
디바이스 식별자 전송 방식 변경 및 테스트 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite build --watch",
     "build": "vite build",
+    "build:dev": "vite build --mode development",
     "preview": "vite preview",
     "test": "vitest",
     "test:run": "vitest run"

--- a/src/__tests__/api.test.js
+++ b/src/__tests__/api.test.js
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { registerDevice, getDevices, deleteDevice, saveReviewUrl } from '../api.js';
+import { ERROR_CODES } from '../constants.js';
+
+// Mock chrome.runtime.sendMessage
+const sendMessageMock = vi.fn();
+global.chrome = {
+  runtime: {
+    sendMessage: sendMessageMock
+  }
+};
+
+describe('api.js', () => {
+  beforeEach(() => {
+    sendMessageMock.mockReset();
+  });
+
+  describe('registerDevice', () => {
+    it('이메일로 등록 요청을 보낸다', async () => {
+      const email = 'test@example.com';
+      const mockResponse = { success: true, data: { email, identifier: 'dev-id' } };
+      sendMessageMock.mockResolvedValue(mockResponse);
+
+      const result = await registerDevice(email);
+
+      expect(sendMessageMock).toHaveBeenCalledWith({
+        type: 'API_REQUEST',
+        request: {
+          endpoint: '/api/v1/members',
+          method: 'POST',
+          body: { email }
+        }
+      });
+      expect(result).toEqual(mockResponse.data);
+    });
+  });
+
+  describe('getDevices', () => {
+    it('식별자를 헤더에 포함하여 디바이스 목록을 조회한다', async () => {
+      const email = 'test@example.com';
+      const identifier = 'my-device-id';
+      const mockResponse = { success: true, data: { devices: [] } };
+      sendMessageMock.mockResolvedValue(mockResponse);
+
+      await getDevices(email, identifier);
+
+      expect(sendMessageMock).toHaveBeenCalledWith({
+        type: 'API_REQUEST',
+        request: {
+          endpoint: '/api/v1/members',
+          method: 'GET',
+          params: { email },
+          headers: { 'X-Device-Id': identifier }
+        }
+      });
+    });
+  });
+
+  describe('deleteDevice', () => {
+    it('식별자를 헤더에 포함하여 디바이스 삭제 요청을 보낸다', async () => {
+      const email = 'test@example.com';
+      const deviceIdentifier = 'my-device-id';
+      const targetDeviceIdentifier = 'target-id';
+      const mockResponse = { success: true, data: null };
+      sendMessageMock.mockResolvedValue(mockResponse);
+
+      await deleteDevice(email, deviceIdentifier, targetDeviceIdentifier);
+
+      expect(sendMessageMock).toHaveBeenCalledWith({
+        type: 'API_REQUEST',
+        request: {
+          endpoint: '/api/v1/device',
+          method: 'DELETE',
+          headers: { 'X-Device-Id': deviceIdentifier },
+          body: { email, targetDeviceIdentifier }
+        }
+      });
+    });
+  });
+
+  describe('saveReviewUrl', () => {
+    it('식별자를 헤더에 포함하여 URL 저장 요청을 보낸다', async () => {
+      const identifier = 'my-device-id';
+      const targetUrl = 'https://example.com';
+      const mockResponse = { success: true, data: { url: targetUrl } };
+      sendMessageMock.mockResolvedValue(mockResponse);
+
+      await saveReviewUrl(identifier, targetUrl);
+
+      expect(sendMessageMock).toHaveBeenCalledWith({
+        type: 'API_REQUEST',
+        request: {
+          endpoint: '/api/v1/reviews',
+          method: 'POST',
+          headers: { 'X-Device-Id': identifier },
+          body: { targetUrl }
+        }
+      });
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('API 실패 시 에러를 던진다', async () => {
+      sendMessageMock.mockResolvedValue({
+        success: false,
+        status: 400,
+        message: 'Bad Request'
+      });
+
+      await expect(registerDevice('test@test.com')).rejects.toThrow('Bad Request');
+    });
+
+    it('네트워크 에러 시 NETWORK_ERROR 코드를 반환한다', async () => {
+      sendMessageMock.mockResolvedValue({
+        success: false,
+        isNetworkError: true,
+        message: 'Network Error'
+      });
+
+      try {
+        await registerDevice('test@test.com');
+      } catch (error) {
+        expect(error.code).toBe(ERROR_CODES.NETWORK_ERROR);
+      }
+    });
+  });
+});

--- a/src/__tests__/background.test.js
+++ b/src/__tests__/background.test.js
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handleApiRequest } from '../api-proxy.js';
+import { CONFIG } from '../config.js';
+
+// Mock global fetch
+global.fetch = vi.fn();
+
+describe('handleApiRequest', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('GET 요청을 올바르게 구성하여 보낸다', async () => {
+    const mockResponse = { data: 'test' };
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => mockResponse
+    });
+
+    const request = {
+      endpoint: '/test',
+      method: 'GET',
+      params: { q: 'hello' }
+    };
+
+    const result = await handleApiRequest(request);
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/test?q=hello'),
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json'
+        })
+      })
+    );
+    expect(result).toEqual({ success: true, data: mockResponse });
+  });
+
+  it('POST 요청과 Body를 올바르게 보낸다', async () => {
+    const mockResponse = { id: 1 };
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => mockResponse
+    });
+
+    const request = {
+      endpoint: '/create',
+      method: 'POST',
+      body: { name: 'item' }
+    };
+
+    await handleApiRequest(request);
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/create'),
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ name: 'item' })
+      })
+    );
+  });
+
+  it('커스텀 헤더를 포함하여 요청을 보낸다', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({})
+    });
+
+    const request = {
+      endpoint: '/header-test',
+      headers: { 'X-Device-Id': '12345' }
+    };
+
+    await handleApiRequest(request);
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          'X-Device-Id': '12345'
+        })
+      })
+    );
+  });
+
+  it('204 응답을 올바르게 처리한다', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 204
+    });
+
+    const result = await handleApiRequest({ endpoint: '/delete' });
+
+    expect(result).toEqual({ success: true, data: null });
+  });
+
+  it('API 에러 응답을 처리한다', async () => {
+    fetch.mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ message: 'Invalid data' })
+    });
+
+    const result = await handleApiRequest({ endpoint: '/error' });
+
+    expect(result).toEqual({
+      success: false,
+      status: 400,
+      message: 'Invalid data'
+    });
+  });
+
+  it('네트워크 에러를 처리한다', async () => {
+    fetch.mockRejectedValue(new Error('Network error'));
+
+    const result = await handleApiRequest({ endpoint: '/network-fail' });
+
+    expect(result).toEqual({
+      success: false,
+      status: 0,
+      message: 'Network error',
+      isNetworkError: true
+    });
+  });
+});

--- a/src/api-proxy.js
+++ b/src/api-proxy.js
@@ -1,0 +1,54 @@
+import { CONFIG } from './config.js';
+
+/**
+ * API 요청 처리 로직
+ * @param {Object} request
+ * @returns {Promise<Object>}
+ */
+export async function handleApiRequest(request) {
+  const { endpoint, method = 'GET', body, params, headers } = request;
+
+  let url = `${CONFIG.BASE_URL}${endpoint}`;
+  if (params) {
+    url += `?${new URLSearchParams(params)}`;
+  }
+
+  const options = {
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(headers || {})
+    }
+  };
+
+  if (body) {
+    options.body = JSON.stringify(body);
+  }
+
+  try {
+    const response = await fetch(url, options);
+
+    // 204 No Content
+    if (response.status === 204) {
+      return { success: true, data: null };
+    }
+
+    let data;
+    try {
+      data = await response.json();
+    } catch (parseError) {
+      console.error('Failed to parse JSON response:', parseError);
+      data = { message: 'Invalid JSON response from server.' };
+    }
+
+    if (!response.ok) {
+      console.error('API request failed:', { url, status: response.status, data });
+      return { success: false, status: response.status, message: data.message };
+    }
+
+    return { success: true, data };
+  } catch (error) {
+    console.error('Network request failed:', { url, error });
+    return { success: false, status: 0, message: error.message, isNetworkError: true };
+  }
+}

--- a/src/api.js
+++ b/src/api.js
@@ -54,7 +54,8 @@ export async function getDevices(email, identifier) {
   return await sendApiRequest({
     endpoint: '/api/v1/members',
     method: 'GET',
-    params: { email, identifier }
+    params: { email },
+    headers: { 'X-Device-Id': identifier }
   });
 }
 
@@ -68,7 +69,8 @@ export async function deleteDevice(email, deviceIdentifier, targetDeviceIdentifi
   return await sendApiRequest({
     endpoint: '/api/v1/device',
     method: 'DELETE',
-    body: { email, deviceIdentifier, targetDeviceIdentifier }
+    headers: { 'X-Device-Id': deviceIdentifier },
+    body: { email, targetDeviceIdentifier }
   });
 }
 
@@ -82,6 +84,7 @@ export async function saveReviewUrl(identifier, targetUrl) {
   return await sendApiRequest({
     endpoint: '/api/v1/reviews',
     method: 'POST',
-    body: { identifier, targetUrl }
+    headers: { 'X-Device-Id': identifier },
+    body: { targetUrl }
   });
 }

--- a/src/background.js
+++ b/src/background.js
@@ -5,7 +5,7 @@
  * API 요청은 CORS 우회를 위해 이 서비스 워커에서 처리한다.
  */
 
-import { CONFIG } from './config.js';
+import { handleApiRequest } from './api-proxy.js';
 
 // ============================================
 // 익스텐션 설치/업데이트 이벤트
@@ -18,53 +18,7 @@ chrome.runtime.onInstalled.addListener((details) => {
   }
 });
 
-// ============================================
-// API 프록시 핸들러
-// ============================================
-async function handleApiRequest(request) {
-  const { endpoint, method = 'GET', body, params } = request;
 
-  let url = `${CONFIG.BASE_URL}${endpoint}`;
-  if (params) {
-    url += `?${new URLSearchParams(params)}`;
-  }
-
-  const options = {
-    method,
-    headers: { 'Content-Type': 'application/json' }
-  };
-
-  if (body) {
-    options.body = JSON.stringify(body);
-  }
-
-  try {
-    const response = await fetch(url, options);
-
-    // 204 No Content
-    if (response.status === 204) {
-      return { success: true, data: null };
-    }
-
-    let data;
-    try {
-      data = await response.json();
-    } catch (parseError) {
-      console.error('Failed to parse JSON response:', parseError);
-      data = { message: 'Invalid JSON response from server.' };
-    }
-
-    if (!response.ok) {
-      console.error('API request failed:', { url, status: response.status, data });
-      return { success: false, status: response.status, message: data.message };
-    }
-
-    return { success: true, data };
-  } catch (error) {
-    console.error('Network request failed:', { url, error });
-    return { success: false, status: 0, message: error.message, isNetworkError: true };
-  }
-}
 
 // ============================================
 // 메시지 리스너 (popup과 통신)

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -224,6 +224,24 @@ export async function handleLogout() {
     return;
   }
 
+  try {
+    showLoading();
+    const storageData = await getStorageData();
+    
+    // 인증된 상태라면 서버에 디바이스 삭제 요청
+    if (storageData.email && storageData.identifier) {
+      await deleteDevice(
+        storageData.email, 
+        storageData.identifier, 
+        storageData.identifier // 자기 자신을 삭제
+      );
+    }
+  } catch (error) {
+    console.warn('서버 디바이스 삭제 실패 (로컬 로그아웃은 진행):', error);
+  } finally {
+    hideLoading();
+  }
+
   await clearStorage();
   elements.saveResult.classList.add('hidden');
   elements.devicesSection.classList.add('hidden');


### PR DESCRIPTION
<!-- PR 템플릿 -->

### 🚀 작업 내용
- API 전송 방식 리팩토링: 
    - `X-Device-Id` 커스텀 헤더 지원을 위해 `src/api-proxy.js` 모듈 분리 및 수정
    - 기존 `api.js`의 함수들을 최신 서버 스펙에 맞게 업데이트
- 로그아웃 로직 개선: 
    - 사용자가 로그아웃 시 서버에서도 디바이스 정보가 제거되도록 `handleLogout`에서 `deleteDevice` 호출 로직 추가
- 테스트 코드 보완:
    - `vitest`를 사용하여 `api.js` 및 `api-proxy.js`에 대한 단위 테스트 추가
    - `npm run build:dev` 스크립트를 추가하여 로컬 서버(`localhost:8080`) 환경에서 즉시 빌드 및 테스트 가능하도록 설정

### 📸 이슈 번호
- close #7 

### ✍ 궁금한 점
- 현재 로그아웃 시 서버 API 호출이 실패하더라도 로컬 데이터는 무조건 삭제하도록 구현했는데, 이 방식이 사용자 경험 측면에서 적절한가?
