### PR TITLE
최초 로그인 시 복습 주기 드롭다운이 비어있는 버그 수정

### DIFF
--- a/src/handlers/auth.js
+++ b/src/handlers/auth.js
@@ -8,6 +8,7 @@ import { STORAGE_KEYS } from '../config.js';
 import { ERROR_CODES } from '../constants.js';
 import { registerDevice, getDevices } from '../api.js';
 import { setStorageData, clearStorage, validateStorageForAuth } from '../storage.js';
+import { handleLoadCycleOptions } from './cycle.js';
 import {
   elements,
   showLoading,
@@ -69,6 +70,7 @@ export async function handleCheckAuth() {
 
     elements.userEmail.textContent = result.email;
     showView('main');
+    await handleLoadCycleOptions();
     showMessage('인증이 완료되었습니다!', 'success');
   } catch (error) {
     if (error.code === ERROR_CODES.UNAUTHORIZED) {


### PR DESCRIPTION
<!-- PR 템플릿 -->

## 🚀 작업 내용

최초 로그인 시 복습 주기 드롭다운이 비어있는 버그 수정

### 원인

`handleCheckAuth()`에서 인증 완료 후 `showView('main')`만 호출하고,
드롭다운을 채우는 `handleLoadCycleOptions()` 호출이 누락되어 있었음.

## 📸 이슈 번호

- close #24 

## ✍ 궁금한 점

- X
